### PR TITLE
Update Notebooks to work with latest version of Sidekick

### DIFF
--- a/car_damage_classification/car_damage_analysis.ipynb
+++ b/car_damage_classification/car_damage_analysis.ipynb
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "zip_path = './preprocessed.zip'\n",
-    "dataset_path = str.split(os.path.basename(dataset_path),'.zip')[0]\n",
+    "dataset_path = str.split(os.path.basename(zip_path),'.zip')[0]\n",
     "zip_ref = zipfile.ZipFile(zip_path, 'r')\n",
     "zip_ref.extractall(dataset_path)\n",
     "zip_ref.close()"
@@ -134,9 +134,7 @@
     "client = sidekick.Deployment(\n",
     "    # Enter URL and token\n",
     "    url=deploy_url,\n",
-    "    token=deploy_token,\n",
-    "    dtypes_in={'image': 'Image (224x224x3)'},\n",
-    "    dtypes_out={'class': 'Categorical (8)'}\n",
+    "    token=deploy_token\n",
     ")"
    ]
   },
@@ -942,7 +940,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/fruit_classification/fruit_analysis.ipynb
+++ b/fruit_classification/fruit_analysis.ipynb
@@ -76,9 +76,7 @@
     "\n",
     "client = sidekick.Deployment(\n",
     "    url=deployment_url,\n",
-    "    token=deployment_token,\n",
-    "    dtypes_in={'image': 'Image (100x100x3)'},\n",
-    "    dtypes_out={'class': 'Categorical (103)'}\n",
+    "    token=deployment_token\n",
     ")"
    ]
   },
@@ -1560,7 +1558,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/skin_lesion_segmentation/skin_lesion_image_segmentation_analysis.ipynb
+++ b/skin_lesion_segmentation/skin_lesion_image_segmentation_analysis.ipynb
@@ -84,9 +84,7 @@
     "client = sidekick.Deployment(\n",
     "    # Enter URL and token\n",
     "    url=deployment_url,\n",
-    "    token=deployment_token,\n",
-    "    dtypes_in={'image': 'Image (64x64x3)'},\n",
-    "    dtypes_out={'mask': 'Image (64x64x1)'}\n",
+    "    token=deployment_token\n",
     ")"
    ]
   },
@@ -803,7 +801,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/solar_panels/solar_analysis.ipynb
+++ b/solar_panels/solar_analysis.ipynb
@@ -55,9 +55,7 @@
     "client = sidekick.Deployment(\n",
     "    # Enter URL and token\n",
     "    url='...',\n",
-    "    token='...',\n",
-    "    dtypes_in={'image': 'Image (300x300x3)'},\n",
-    "    dtypes_out={'prob': 'Float (1)'}\n",
+    "    token='...'\n",
     ")\n",
     "\n",
     "#preprocessed dataset\n",
@@ -1285,7 +1283,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/yeast_dna/Yeast DNA Model Evaluation.ipynb
+++ b/yeast_dna/Yeast DNA Model Evaluation.ipynb
@@ -70,9 +70,7 @@
    "source": [
     "client = sidekick.Deployment(\n",
     "    url='<insert deployment URL>',\n",
-    "    token='<insert deployment token>',\n",
-    "    dtypes_in={'seq': 'Numpy (4x70x1)'},\n",
-    "    dtypes_out={'growth_rate': 'Numpy (1)'}\n",
+    "    token='<insert deployment token>'\n",
     ")"
    ]
   },
@@ -274,7 +272,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.3"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
All notebooks in the Community code repository have been updated to work with the latest version of Sidekick. The input and output parameters should no longer be used in the instantiation of the Deployment class since these are now fetched from the Peltarion platform.

The dataset path was not set correctly in the evaluation notebook for the Car damage classification tutorial. This has been fixed.

